### PR TITLE
Revert "perf: avoid downloading existing fonts"

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -171,8 +171,6 @@ function parseFontsFromCss (content: string, fontsPath: string): FontInputOutput
       const urlPathname = new URL(url).pathname
       const ext = extname(urlPathname)
       if (ext.length < 2) { continue }
-      if (fonts.find(font => font.inputFont === url)) { continue }
-
       const filename = basename(urlPathname, ext) || ''
       const newFilename = formatFontFileName('{_family}-{weight}-{i}.{ext}', {
         comment: comment || '',


### PR DESCRIPTION
Reverts datalogix/google-fonts-helper#52

see https://github.com/bernhardberger/google-fonts-helper/commit/5644dbda47b3bc35b0f8bdc704d454403951b965

this is a critical issue as it links to the CDN for fonts that are not downloaded which could cause GDPR compaints and legal issues in EU countries.