### PR TITLE
fix: do not remove `outputDir` directory when `overwriting` is enabled

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
 import { extname, posix, resolve, dirname } from 'node:path'
 import { ofetch } from 'ofetch'
 import { Hookable } from 'hookable'
@@ -75,10 +75,6 @@ export class Downloader extends Hookable<DownloaderHooks> {
       }
 
       overwriting = true
-    }
-
-    if (overwriting) {
-      rmSync(outputDir, { recursive: true, force: true })
     }
 
     await this.callHook('download:start')


### PR DESCRIPTION
When we enable `overwriting` it removes the `outputDir` folder completely and this folder may contain application files.