### PR TITLE
feat: New getFontInfo function

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,27 +138,48 @@ downloader.hook('download:complete', () => {
 await downloader.execute()
 ```
 
-### `getFontInfo(url: string, option?: DownloadOptions): Map<string, string>, string`
+### `getFontInfo(url: string, option?: DownloadOptions): fontMaps: Map<string, string>, localCSS: string`
 
 Use this function if you'd like more control over font download caching for your project. For example, using [Eleventy Fetch](https://www.11ty.dev/docs/plugins/fetch/#fetch), which incorporates local caching.
 
 ```ts
-const { css, fonts } = getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
+// fontsPath is the path prepended to the local font name in the @font-face url()
+const fontsPath = './fonts'
+const cssPath = './css'
+
+const { localCSS, fontMaps } = await getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
   base64: false,
-  overwriting: false,
-  outputDir: './',
-  stylePath: 'fonts.css',
-  fontsDir: 'fonts',
-  fontsPath: './fonts'
+  fontsPath: fontsPath
 })
 
-for (const [url, filename] of fonts) {
-  // Save locally to `fontsPath/filename`
-  await yourDownloadFunction(url, `${fontsPath}/${filename}`)
+const result = async function () {
+  let success: boolean = true
+
+  try {
+    await fs.writeFile(cssPath, localCSS) 
+  } catch (error) {
+    success = false
+    console.error(`Failed to save CSS`, error)
+  }
+
+  return success
 }
 
-const fs = require('fs')
-fs.writeFileSync(`${outputDir}/${stylePath}`, css)
+const result = async function () {
+  let success: boolean = true
+
+  for (const [url, filename] of fontMaps) {
+    try {
+      // Save locally to `fontsPath/filename`
+      await yourDownloadFunction(url, `${fontsPath}/${filename}`)
+    } catch (error) {
+      success = false
+      console.error(`Failed to save font: ${filename}`, error)
+    }
+  }
+
+  return success
+}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ downloader.hook('download:complete', () => {
 await downloader.execute()
 ```
 
-### `getFontInfo(url: string, option?: DownloadOptions): fontMaps: Map<string, string>, localCSS: string`
+### `getFontInfo(url: string, options?: DownloadOptions): [ Map<string, string>, string ]`
 
 Use this function if you'd like more control over font download caching for your project. For example, using [Eleventy Fetch](https://www.11ty.dev/docs/plugins/fetch/#fetch), which incorporates local caching.
 
@@ -147,7 +147,7 @@ Use this function if you'd like more control over font download caching for your
 const fontsPath = './fonts'
 const cssPath = './css'
 
-const { localCSS, fontMaps } = await getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
+const [localCSS, fontMaps] = await getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
   base64: false,
   fontsPath: fontsPath
 })

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Use this function if you'd like more control over font download caching for your
 const fontsPath = './fonts'
 const cssPath = './css'
 
-const [localCSS, fontMaps] = await getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
+const [localCSS, fontsMap] = await getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
   base64: false,
   fontsPath: fontsPath
 })
@@ -168,7 +168,7 @@ const result = async function () {
 const result = async function () {
   let success: boolean = true
 
-  for (const [url, filename] of fontMaps) {
+  for (const [url, filename] of fontsMap) {
     try {
       // Save locally to `fontsPath/filename`
       await yourDownloadFunction(url, `${fontsPath}/${filename}`)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ downloader.hook('download:complete', () => {
 await downloader.execute()
 ```
 
+### `getFontInfo(url: string, option?: DownloadOptions): Map<string, string>, string`
+
+Use this function if you'd like more control over font download caching for your project. For example, using [Eleventy Fetch](https://www.11ty.dev/docs/plugins/fetch/#fetch), which incorporates local caching.
+
+```ts
+const { css, fonts } = getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
+  base64: false,
+  overwriting: false,
+  outputDir: './',
+  stylePath: 'fonts.css',
+  fontsDir: 'fonts',
+  fontsPath: './fonts'
+})
+
+for (const [url, filename] of fonts) {
+  // Save locally to `fontsPath/filename`
+  await yourDownloadFunction(url, `${fontsPath}/${filename}`)
+}
+
+const fs = require('fs')
+fs.writeFileSync(`${outputDir}/${stylePath}`, css)
+```
+
 ## License
 
 [MIT License](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Use this function if you'd like more control over font download caching for your
 const fontsPath = './fonts'
 const cssPath = './css'
 
-const [localCSS, fontsMap] = await getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
+const [fontsMap, localCSS] = await getFontInfo('https://fonts.googleapis.com/css2?family=Roboto', {
   base64: false,
   fontsPath: fontsPath
 })

--- a/src/download.ts
+++ b/src/download.ts
@@ -3,3 +3,22 @@ import { Downloader, DownloadOptions } from './downloader'
 export function download (url: string, options?: Partial<DownloadOptions>) {
   return new Downloader(url, options)
 }
+
+export async function getFontInfo (url: string, options?: Partial<DownloadOptions>): Promise<{ fontURLs: Map<string, string>, localCSS: string }> {
+  const info = new Downloader(url, options)
+  const { fonts, css } = await info.extractFontInfo()
+
+  let localCSS: string = ''
+  const fontURLs: Map<string, string> = new Map()
+
+  // Replace remote with local font url() paths
+  for (const font of fonts) {
+    localCSS = css.replace(font.inputText, font.outputText)
+    fontURLs.set(font.inputFont, font.outputFont)
+  }
+
+  return {
+    localCSS,
+    fontURLs
+  }
+}

--- a/src/download.ts
+++ b/src/download.ts
@@ -8,12 +8,12 @@ export async function getFontInfo (url: string, options?: Partial<DownloadOption
   const info = new Downloader(url, options)
   const { fonts, css } = await info.extractFontInfo()
 
-  let localCSS: string = ''
+  let localCSS: string = css
   const fontMaps: Map<string, string> = new Map()
 
   // Replace remote with local font url() paths
   for (const font of fonts) {
-    localCSS = css.replace(font.inputText, font.outputText)
+    localCSS = localCSS.replace(font.inputText, font.outputText)
     fontMaps.set(font.inputFont, font.outputFont)
   }
 

--- a/src/download.ts
+++ b/src/download.ts
@@ -4,21 +4,18 @@ export function download (url: string, options?: Partial<DownloadOptions>) {
   return new Downloader(url, options)
 }
 
-export async function getFontInfo (url: string, options?: Partial<DownloadOptions>): Promise<{ fontMaps: Map<string, string>, localCSS: string }> {
+export async function getFontInfo (url: string, options?: Partial<DownloadOptions>): Promise<[Map<string, string>, string]> {
   const info = new Downloader(url, options)
   const { fonts, css } = await info.extractFontInfo()
 
   let localCSS: string = css
-  const fontMaps: Map<string, string> = new Map()
+  const fontsMap: Map<string, string> = new Map()
 
   // Replace remote with local font url() paths
   for (const font of fonts) {
     localCSS = localCSS.replace(font.inputText, font.outputText)
-    fontMaps.set(font.inputFont, font.outputFont)
+    fontsMap.set(font.inputFont, font.outputFont)
   }
 
-  return {
-    localCSS,
-    fontMaps
-  }
+  return [fontsMap, localCSS]
 }

--- a/src/download.ts
+++ b/src/download.ts
@@ -4,21 +4,21 @@ export function download (url: string, options?: Partial<DownloadOptions>) {
   return new Downloader(url, options)
 }
 
-export async function getFontInfo (url: string, options?: Partial<DownloadOptions>): Promise<{ fontURLs: Map<string, string>, localCSS: string }> {
+export async function getFontInfo (url: string, options?: Partial<DownloadOptions>): Promise<{ fontMaps: Map<string, string>, localCSS: string }> {
   const info = new Downloader(url, options)
   const { fonts, css } = await info.extractFontInfo()
 
   let localCSS: string = ''
-  const fontURLs: Map<string, string> = new Map()
+  const fontMaps: Map<string, string> = new Map()
 
   // Replace remote with local font url() paths
   for (const font of fonts) {
     localCSS = css.replace(font.inputText, font.outputText)
-    fontURLs.set(font.inputFont, font.outputFont)
+    fontMaps.set(font.inputFont, font.outputFont)
   }
 
   return {
     localCSS,
-    fontURLs
+    fontMaps
   }
 }

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -102,10 +102,23 @@ export class Downloader extends Hookable<DownloaderHooks> {
     return true
   }
 
+  async extractFontInfo (): Promise<{ fonts: FontInputOutput[], css: string }> {
+    if (!isValidURL(this.url)) {
+      throw new Error('Invalid Google Fonts URL')
+    }
+
+    const { headers, fontsPath } = this.config
+
+    const _css = await ofetch(this.url, { headers })
+    const { fonts, css } = parseFontsFromCss(_css, fontsPath)
+
+    return { fonts, css }
+  }
+
   private async downloadFonts (fonts: FontInputOutput[]) {
     const { headers, base64, outputDir, fontsDir } = this.config
     const downloadedFonts: FontInputOutput[] = []
-    const _fonts:FontInputOutput[] = []
+    const _fonts: FontInputOutput[] = []
 
     for (const font of fonts) {
       const downloadedFont = downloadedFonts.find(f => f.inputFont === font.inputFont)


### PR DESCRIPTION
The purpose of adding this functionality is to allow download management of font files outside of the google-fonts-helper package. I want more control over when font files are fetched using caching so that font files aren't downloaded into my Eleventy dev project unnecessarily often.

Changes:
- Added new extractFontInfo method to Downloader class.
- Added getFontInfo function export to access method.
- Updated README with example

Here's an example of how I'm using this in an Eleventy project.

Global data file:
```cjs
export default {
  css: async function () {
    return localCSS;
  },
  files: async function () {
    const fonts = [];

    for (const [url, fileName] of fontMaps) {
      const fontBuffer = await EleventyFetch(url, {
        duration: "1w",
        type: "buffer",
      });
      fonts.push({fontBuffer, fileName});
    }
    return fonts;
  },
  buildFontPath: buildFontPath,
  buildCSS: buildCSS,
};
```

.eleventy.js config:
```cjs
// Write configured Google Fonts to build output
  eleventyConfig.on("eleventy.after",
    async () => {
      const fontBuffers = await fonts.files();

      for (const { fontBuffer, fileName } of fontBuffers) {
        const outputPath = path.join('_site', fonts.buildFontPath, fileName);
        const outputDir = path.dirname(outputPath);
        
        await fs.mkdir(outputDir, { recursive: true });
        await fs.writeFile(outputPath, fontBuffer);
      }
    }
  );
```