### PR TITLE
fix: write downloaded bytes to file directly

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -146,7 +146,7 @@ export class Downloader extends Hookable<DownloaderHooks> {
         const fontPath = resolve(outputDir, fontsDir, font.outputFont)
 
         mkdirSync(dirname(fontPath), { recursive: true })
-        writeFileSync(fontPath, buffer, 'binary')
+        writeFileSync(fontPath, buffer)
       }
 
       _fonts.push(font)

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -146,7 +146,7 @@ export class Downloader extends Hookable<DownloaderHooks> {
         const fontPath = resolve(outputDir, fontsDir, font.outputFont)
 
         mkdirSync(dirname(fontPath), { recursive: true })
-        writeFileSync(fontPath, buffer.toString(), 'utf-8')
+        writeFileSync(fontPath, buffer, 'binary')
       }
 
       _fonts.push(font)


### PR DESCRIPTION
For some reason the latest update started to write extra bytes inside font files which corrupt them. I suspect this is because the byte array is converted to a utf-8 string, which causes the font data to mutate in some way.

This pull request avoids the unnecessary conversion by writing the buffer directly to a file with binary encoding.